### PR TITLE
use host network for IP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     volumes:
       - ./screenshots:/usr/screenshots
+    network_mode: host
   screen:
     build: ./screen-driver
     volumes:


### PR DESCRIPTION
- Simple change to show the host's IP address rather than the internal network of docker
- I can't find another way to do it, other than to just use the host network. Not sure if this has bad implications for security